### PR TITLE
nats-extra: Release v0.2.0

### DIFF
--- a/nats-extra/Cargo.toml
+++ b/nats-extra/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nats-extra"
 authors = ["Tomasz Pietrek <tomasz@nats.io>"]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Set of utilities and extensions for the Core NATS of the async-nats crate"
 license = "Apache-2.0"


### PR DESCRIPTION
## Overview

A release improving `request_many`.

## What's Changed
* Add `termination_reason` to `Responses`, allowing to check why the responses iterator has been closed (#4)
* Properly handle `no responders` and close the iterator when encountered (#4)