### PR TITLE
Release v0.3.0

### DIFF
--- a/nats-extra/Cargo.toml
+++ b/nats-extra/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nats-extra"
 authors = ["Tomasz Pietrek <tomasz@nats.io>"]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "Set of utilities and extensions for the Core NATS of the async-nats crate"
 license = "Apache-2.0"


### PR DESCRIPTION
## Overview

This Release decouples versioning with the client thanks to switch to Client traits recently released in `async-nats`.

## What's Changed
* Swap implementation of nats-extra to use client traits by @Jarema in https://github.com/synadia-io/orbit.rs/pull/8


**Full Changelog**: https://github.com/synadia-io/orbit.rs/compare/nats-extra/v0.2.0...nats-extra/v0.3.0

Signed-off-by: Tomasz Pietrek <tomasz@nats.io>