### PR TITLE
Allow CDLA-Permissive-2.0 license for webpki-roots

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,7 @@ allow = [
     "OpenSSL",
     "Unicode-DFS-2016",
     "Unicode-3.0",
+    "CDLA-Permissive-2.0",
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
## Summary
- `webpki-roots` (v0.26.11 / v1.0.6) changed its license from ISC to `CDLA-Permissive-2.0`
- This broke the `cargo deny check licenses` CI job
- Adds `CDLA-Permissive-2.0` to the allowed licenses list in `deny.toml`