### PR TITLE
Add docs.nats.io examples to main

### DIFF
--- a/jetstream-extra/examples/docs_atomic_batch.rs
+++ b/jetstream-extra/examples/docs_atomic_batch.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Atomic batch publish: store every line item of an order, or none of them.
+//!
+//! The ORDERS stream is created with `allow_atomic_publish` enabled. The three
+//! line items are added under one batch id and committed together, so a reader
+//! never sees a partially written order. The commit ack reports the batch id
+//! and how many messages were stored.
+//!
+//! ```bash
+//! nats-server -js
+//! cargo run -p jetstream-extra --example docs_atomic_batch
+//! ```
+
+use async_nats::jetstream::stream::Config;
+use jetstream_extra::batch_publish::BatchPublishExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = async_nats::connect("nats://localhost:4222").await?;
+    let js = async_nats::jetstream::new(client);
+
+    // Atomic batches require a stream with allow_atomic_publish set.
+    js.create_stream(Config {
+        name: "ORDERS".into(),
+        subjects: vec!["orders.>".into()],
+        allow_atomic_publish: true,
+        ..Default::default()
+    })
+    .await?;
+
+    // NATS-DOC-START
+    // Open a batch, add the first two line items, then commit with the third.
+    // Every message carries the same batch id; the order is stored only if the
+    // commit succeeds.
+    let mut batch = js.batch_publish().build();
+    batch
+        .add("orders.created", r#"{"sku":"NATS-TEE","qty":2}"#.into())
+        .await?;
+    batch
+        .add("orders.created", r#"{"sku":"NATS-MUG","qty":1}"#.into())
+        .await?;
+    let ack = batch
+        .commit("orders.created", r#"{"sku":"NATS-CAP","qty":3}"#.into())
+        .await?;
+
+    println!(
+        "batch {} committed {} line items",
+        ack.batch_id, ack.batch_size
+    );
+    // NATS-DOC-END
+
+    Ok(())
+}

--- a/jetstream-extra/examples/docs_learn_jetstream_get_direct_batch_get.rs
+++ b/jetstream-extra/examples/docs_learn_jetstream_get_direct_batch_get.rs
@@ -1,0 +1,57 @@
+// Copyright 2026 Synadia Communications Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Batch Direct Get: read several stored messages in one request.
+//!
+//! The ORDERS stream has `allow_direct` enabled, so reads are served from any
+//! replica without going through a consumer. `get_batch` asks for up to N
+//! messages starting at a sequence and returns them as a stream, in order.
+//!
+//! ```bash
+//! nats-server -js
+//! cargo run -p jetstream-extra --example docs_learn_jetstream_get_direct_batch_get
+//! ```
+
+use async_nats::jetstream::stream::Config;
+use futures::StreamExt;
+use jetstream_extra::batch_fetch::BatchFetchExt;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = std::env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".into());
+    let client = async_nats::connect(url).await?;
+    let js = async_nats::jetstream::new(client);
+
+    // Direct Get reads are served straight from the stream's storage, so the
+    // stream must be created with allow_direct.
+    js.create_stream(Config {
+        name: "ORDERS".into(),
+        subjects: vec!["orders.>".into()],
+        allow_direct: true,
+        ..Default::default()
+    })
+    .await?;
+
+    // NATS-DOC-START
+    // Fetch up to 3 messages starting at stream sequence 1, all in one request.
+    let mut messages = js.get_batch("ORDERS", 3).sequence(1).send().await?;
+
+    // The batch arrives as a stream of messages in sequence order.
+    while let Some(msg) = messages.next().await {
+        let msg = msg?;
+        println!("seq {} on subject {}", msg.sequence, msg.subject);
+    }
+    // NATS-DOC-END
+
+    Ok(())
+}

--- a/jetstream-extra/examples/docs_learn_jetstream_get_direct_batch_get.rs
+++ b/jetstream-extra/examples/docs_learn_jetstream_get_direct_batch_get.rs
@@ -42,6 +42,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     })
     .await?;
 
+    // Seed a few orders so the batch read below has messages to return.
+    for sku in ["NATS-TEE", "NATS-MUG", "NATS-CAP"] {
+        js.publish("orders.created", format!(r#"{{"sku":"{sku}"}}"#).into())
+            .await?
+            .await?;
+    }
+
     // NATS-DOC-START
     // Fetch up to 3 messages starting at stream sequence 1, all in one request.
     let mut messages = js.get_batch("ORDERS", 3).sequence(1).send().await?;


### PR DESCRIPTION
Moves the two documentation examples from the `jetstream-docs` branch into `jetstream-extra/examples/` on main (`docs_atomic_batch.rs`, `docs_learn_jetstream_get_direct_batch_get.rs`; additive only).

Why: the new docs.nats.io build fetches these snippets at build time; on main the existing `jetstreamext-extra` workflow compiles them 4 ways (check --examples, clippy --examples, build --all-targets, min-versions) automatically. Verified locally: `cargo check --examples` passes, rustfmt-clean.

Note: please keep the `jetstream-docs` branch until the docs repo's fetch config is switched to `main` (follow-up PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)